### PR TITLE
Replace `showThumbnailPreview` with `timlinePreview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following properties below are accessible and writable to use:
 | `title`                | Title positioned on top of the video player                                                           | String  | `undefined`   |
 | `videoFilePath`        | Relative file path to .mp4 video                                                                      | String  | `undefined`   |
 | `poster`               | File path to poster image. It can be a relative or absolute URL                                       | String  | `undefined`   |
-| `showThumbnailPreview` | Determines if the thumbnail previews show above the timeline track                                    | Boolean | `false`       |
+| `timelinePreview`      | Determines if the timeline preview above the track appears when hovering                              | Boolean | `false`       |
 | `volume`               | The volume scaled from 0-1                                                                            | Number  | `0.5`         |
 | `time`                 | The current time in seconds of the video playback                                                     | Number  | `0`           |
 | `skipBy`               | Skip ahead or behind (in seconds) the current time based on the right or left arrow keys respectively | Number  | `5`           |
@@ -108,7 +108,7 @@ Custom property | Description | Default Value
 `--video-track-fill-color`                | Track fill color                        | `#d32f2f`
 `--video-thumb-color`                     | Thumb color used for dragging           | `#fff`
 `--video-control-icons-background-hover-color` | Control icons background hover color  | `#d32f2f`
-`--video-thumbnail-background-color`      | Thumbnail track background color        | `rgba(255,255,255,.9)`
+`---video-time-preview-background-color`  | Timeline preview background color       | `#d32f2f`
 `--video-menu-background-color`           | Menu background color                   | `rgba(255,255,255,.9)`
 `--video-menu-item-color`                 | Menu item background color              | `rgba(255,255,255,.9)`
 `--video-menu-item-icon-color`            | Menu icon color                         | `black`

--- a/mp4-video-player.js
+++ b/mp4-video-player.js
@@ -49,7 +49,7 @@ class MP4VideoPlayer extends PolymerElement {
           </div>
           <div class="track" 
             on-mouseenter="_toggleThumbnail"
-            on-mousemove="_updateThumbnailPosition"
+            on-mousemove="_updatePreviewPosition"
             on-mouseleave="_toggleThumbnail"
             on-mousedown="_handleDown"
             on-touchstart="_handleDown"> 
@@ -373,12 +373,11 @@ class MP4VideoPlayer extends PolymerElement {
   }
 
   /**
-   * Update thumbnail preview position on
-   * track
+   * Update preview position on track
    * @param {MouseEvent} event mouse-move event
    * @private
    */
-  _updateThumbnailPosition(event) {
+  _updatePreviewPosition(event) {
     if (this.showThumbnailPreview) {
       const thumbnail = this._getShadowElementById('preview_thumbnail');
       const containerRec = this._getShadowElementById('video_container').getBoundingClientRect();

--- a/mp4-video-player.js
+++ b/mp4-video-player.js
@@ -389,15 +389,16 @@ class MP4VideoPlayer extends PolymerElement {
       const minVal = containerRec.left - progressBarRec.left + 10;
       const maxVal = containerRec.right - progressBarRec.left - thumbnailWidth - 10;
       const mousePosX = event.pageX;
-      let previewPos = mousePosX - progressBarRec.left - thumbnailWidth / 2;
+      const relativePosX = mousePosX - progressBarRec.left;
+      let previewPos = relativePosX - thumbnailWidth / 2;
       if (previewPos < minVal) {
         previewPos = minVal;
       }
       if (previewPos > maxVal) {
         previewPos = maxVal;
       }
-      thumbnail.style.left = `${previewPos}px`;
-      this.previewTime = this._formatTime(video.duration * (mousePosX / container.offsetWidth));
+      thumbnail.style.left = `${previewPos + 5}px`; // TODO: very hacky. This is because of the 5px padding..
+      this.previewTime = this._formatTime(video.duration * (relativePosX / event.currentTarget.offsetWidth));
     }
   }
 

--- a/mp4-video-player.js
+++ b/mp4-video-player.js
@@ -27,7 +27,7 @@ class MP4VideoPlayer extends PolymerElement {
         </video>
         <div class="video-controls">
           <template is="dom-if" if={{timelinePreview}}>
-            <div id="preview_thumbnail" class="thumbnail">[[previewTime]]</div>
+            <div id="time_preview" class="preview">[[previewTime]]</div>
           </template>
           <div id="menu" class="dropdown-menu" hidden>
             <button type="button" class="menu-item">
@@ -334,7 +334,7 @@ class MP4VideoPlayer extends PolymerElement {
    */
   _togglePreview(event) {
     if (this.timelinePreview) {
-      const thumbnail = this._getShadowElementById('preview_thumbnail');
+      const thumbnail = this._getShadowElementById('time_preview');
       const { type } = event;
       let toggle = false;
       if (type === 'mouseenter') {
@@ -380,7 +380,7 @@ class MP4VideoPlayer extends PolymerElement {
   _updatePreviewPosition(event) {
     if (this.timelinePreview) {
       const video = this._getShadowElementById('video_player');
-      const thumbnail = this._getShadowElementById('preview_thumbnail');
+      const thumbnail = this._getShadowElementById('time_preview');
       const container = this._getShadowElementById('video_container');
       const containerRec = container.getBoundingClientRect();
       const thumbnailRec = thumbnail.getBoundingClientRect();

--- a/mp4-video-player.js
+++ b/mp4-video-player.js
@@ -26,8 +26,8 @@ class MP4VideoPlayer extends PolymerElement {
           <source src$="{{videoFilePath}}" type="video/mp4">
         </video>
         <div class="video-controls">
-          <template is="dom-if" if={{showThumbnailPreview}}>
-            <div id="preview_thumbnail" class="thumbnail">THUMBNAIL PREVIEW MOUSE OVER POSITION: [[xPosition]]</div>
+          <template is="dom-if" if={{timelinePreview}}>
+            <div id="preview_thumbnail" class="thumbnail">[[previewTime]]</div>
           </template>
           <div id="menu" class="dropdown-menu" hidden>
             <button type="button" class="menu-item">
@@ -48,9 +48,9 @@ class MP4VideoPlayer extends PolymerElement {
             </button>
           </div>
           <div class="track" 
-            on-mouseenter="_toggleThumbnail"
+            on-mouseenter="_togglePreview"
             on-mousemove="_updatePreviewPosition"
-            on-mouseleave="_toggleThumbnail"
+            on-mouseleave="_togglePreview"
             on-mousedown="_handleDown"
             on-touchstart="_handleDown"> 
             <div id="track_slider" class="slider">
@@ -147,7 +147,7 @@ class MP4VideoPlayer extends PolymerElement {
         reflectToAttribute: true
       },
       /* Determines if the timeline preview above the track appears when hovering */
-      showThumbnailPreview: {
+      timelinePreview: {
         type: Boolean,
         value: true,
         reflectToAttribute: true
@@ -332,8 +332,8 @@ class MP4VideoPlayer extends PolymerElement {
    * @param {MouseEvent} event mouse-enter/leave event
    * @private
    */
-  _toggleThumbnail(event) {
-    if (this.showThumbnailPreview) {
+  _togglePreview(event) {
+    if (this.timelinePreview) {
       const thumbnail = this._getShadowElementById('preview_thumbnail');
       const { type } = event;
       let toggle = false;
@@ -378,9 +378,11 @@ class MP4VideoPlayer extends PolymerElement {
    * @private
    */
   _updatePreviewPosition(event) {
-    if (this.showThumbnailPreview) {
+    if (this.timelinePreview) {
+      const video = this._getShadowElementById('video_player');
       const thumbnail = this._getShadowElementById('preview_thumbnail');
-      const containerRec = this._getShadowElementById('video_container').getBoundingClientRect();
+      const container = this._getShadowElementById('video_container');
+      const containerRec = container.getBoundingClientRect();
       const thumbnailRec = thumbnail.getBoundingClientRect();
       const progressBarRec = event.currentTarget.getBoundingClientRect();
       const thumbnailWidth = thumbnailRec.width;
@@ -395,7 +397,7 @@ class MP4VideoPlayer extends PolymerElement {
         previewPos = maxVal;
       }
       thumbnail.style.left = `${previewPos}px`;
-      this.xPosition = mousePosX;
+      this.previewTime = this._formatTime(video.duration * (mousePosX / container.offsetWidth));
     }
   }
 

--- a/player-styles.js
+++ b/player-styles.js
@@ -233,7 +233,7 @@ const playerStyles = html`
     .preview {
       position: absolute;
       width: 50px;
-      background: var(--video-thumbnail-background-color, #d32f2f);
+      background: var(--video-time-preview-background-color, #d32f2f);
       box-shadow: 0 1px 2px rgba(0,0,0,.15);
       bottom: 100%;
       border-radius: 5px;
@@ -251,7 +251,7 @@ const playerStyles = html`
       content: '';
       border-width: 5px;
       border-style: solid;
-      border-color: var(--video-thumbnail-background-color, #d32f2f) transparent transparent transparent;
+      border-color: var(--video-time-preview-background-color, #d32f2f) transparent transparent transparent;
       transform: translateX(-50%);
     }
 

--- a/player-styles.js
+++ b/player-styles.js
@@ -232,7 +232,7 @@ const playerStyles = html`
     
     .thumbnail {
       position: absolute;
-      width: 40px;
+      width: 50px;
       background: var(--video-thumbnail-background-color, #d32f2f);
       box-shadow: 0 1px 2px rgba(0,0,0,.15);
       bottom: 100%;

--- a/player-styles.js
+++ b/player-styles.js
@@ -230,7 +230,7 @@ const playerStyles = html`
       display: flex;
     }
     
-    .thumbnail {
+    .preview {
       position: absolute;
       width: 50px;
       background: var(--video-thumbnail-background-color, #d32f2f);
@@ -242,7 +242,7 @@ const playerStyles = html`
       opacity: 0;
     }
     
-    .thumbnail::before {
+    .preview::before {
       border-left: 4px solid transparent;
       border-right: 4px solid transparent;
       position: absolute;
@@ -258,7 +258,6 @@ const playerStyles = html`
     .appear {
       opacity: 1;
     }
-
 
     .dropdown-menu {
       position: absolute;

--- a/player-styles.js
+++ b/player-styles.js
@@ -232,24 +232,27 @@ const playerStyles = html`
     
     .thumbnail {
       position: absolute;
-      width: 168px;
-      height: 96px;
-      background: var(--video-thumbnail-background-color, rgba(255,255,255,.9));
+      width: 40px;
+      background: var(--video-thumbnail-background-color, #d32f2f);
       box-shadow: 0 1px 2px rgba(0,0,0,.15);
       bottom: 100%;
       border-radius: 5px;
+      color: white;
       text-align: center;
       opacity: 0;
     }
     
-    .thumbnail::after { 
+    .thumbnail::before {
+      border-left: 4px solid transparent;
+      border-right: 4px solid transparent;
       position: absolute;
       top: 100%;
       left: 50%;
       content: '';
       border-width: 5px;
       border-style: solid;
-      border-color: var(--video-thumbnail-background-color, rgba(255,255,255,.9)) transparent transparent transparent;
+      border-color: var(--video-thumbnail-background-color, #d32f2f) transparent transparent transparent;
+      transform: translateX(-50%);
     }
 
     .appear {

--- a/test/mp4-video-player_test.html
+++ b/test/mp4-video-player_test.html
@@ -95,6 +95,12 @@
           expect(skipBy).not.to.be.undefined;
           expect(skipBy).to.be.an('number');
         });
+
+        test('timelinePreview prop can be set', () => {
+          const { timelinePreview } = player;
+          expect(timelinePreview).not.to.be.undefined;
+          expect(timelinePreview).to.be.an('boolean');
+        });
       });
 
       suite('toggling functionality', () => {

--- a/test/mp4-video-player_test.html
+++ b/test/mp4-video-player_test.html
@@ -241,7 +241,7 @@
             '--video-track-bar-color': 'blue',
             '--video-track-fill-color': 'green',
             '--video-thumb-color': 'yellow',
-            '--video-thumbnail-background-color': 'orange',
+            '--video-time-preview-background-color': 'orange',
             '--video-menu-background-color': 'pink',
             '--video-menu-item-color': 'Cyan',
             '--video-menu-item-icon-color': 'DarkViolet',
@@ -260,6 +260,9 @@
 
           const trackThumb = player.shadowRoot.querySelector('.thumb');
           assertComputed(trackThumb, 'yellow', '--video-thumb-color');
+
+          const timePreview = player.shadowRoot.querySelector('.thumb');
+          assertComputed(timePreview, 'orange', '--video-time-preview-background-color');
       
           const menu = player.shadowRoot.querySelector('.dropdown-menu');
           assertComputed(menu, 'pink', '--video-menu-background-color');

--- a/test/mp4-video-player_test.html
+++ b/test/mp4-video-player_test.html
@@ -26,7 +26,7 @@
           poster="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.jpg" 
           video-file-path="../assets/sample.mp4"
           skipBy=10
-          show-thumbnail-preview>
+          timeline-preview>
         </mp4-video-player>
       </template>
     </test-fixture>


### PR DESCRIPTION
Currently, the `showThumbnailPreview`  is rendered useless as the implementation is yet to be completed. Therefore I have replaced this property with `timelinePreview` which will display the expected current time when hovering over the video timeline.