### PR TITLE
Redirect users to demo page for Vercel deployments

### DIFF
--- a/mp4-video-player.js
+++ b/mp4-video-player.js
@@ -37,7 +37,6 @@ class MP4VideoPlayer extends PolymerElement {
           id="video_player" 
           playsinline
           on-dblclick="_toggleFullscreen"
-          crossorigin="anonymous"
           preload="metadata" 
           src$="[[src]]" 
           autoplay$="[[autoPlay]]"

--- a/mp4-video-player.js
+++ b/mp4-video-player.js
@@ -37,6 +37,7 @@ class MP4VideoPlayer extends PolymerElement {
           id="video_player" 
           playsinline
           on-dblclick="_toggleFullscreen"
+          crossorigin="anonymous"
           preload="metadata" 
           src$="[[src]]" 
           autoplay$="[[autoPlay]]"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "redirects": [
+    { "source": "/", "destination": "/demo" }
+  ]
+}


### PR DESCRIPTION
* redirect users to the `/demo` path of the video player from the base `/` path for Vercel deployments
* replace the sample video with a higher quality version