### PR TITLE
BREAKING CHANGE: remove min width/height css props

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 .eslintignore
 .gitignore
 .travis.yml
+vercel.json
 demo/
 test/
 report/

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ The following custom CSS variables are also available for custom styling the vid
 Custom property | Description | Default Value
 ------------------------------------------|-------------------------------------------------------------|----------------------
 `--video-title-color`                     | Color of the video title                | `rgba(255,255,255,.9)`
-`--video-min-width`                       | The minimum width of the video player   | `600px`
-`--video-min-height`                      | The minimum height of the video player  | `400px`
 `--video-large-play-button-color`         | Large play button color                 | `#d32f2f`
 `--video-large-play-button-hover-color`   | Large play button hover color           | `#9a0007`
 `--video-track-fill-color`                | Track fill color                        | `#d32f2f`

--- a/player-styles.js
+++ b/player-styles.js
@@ -4,8 +4,6 @@ const playerStyles = html`
   <style>
     :host {
       display: block;
-      min-width: var(--video-min-width, 600px);
-      min-height: var(--video-min-height, 400px);
       user-select: none;
     }
 

--- a/test/mp4-video-player_test.html
+++ b/test/mp4-video-player_test.html
@@ -360,8 +360,6 @@
       suite('player styling', () => {
         test('CSS properties are being applied..', () => {
           player.updateStyles({
-            '--video-min-width': '750px',
-            '--video-min-height': '300px',
             '--video-title-color': 'red',
             '--video-track-bar-color': 'blue',
             '--video-track-fill-color': 'green',
@@ -375,9 +373,6 @@
             '--video-pulse-icon-color': 'LightSteelBlue'
           });
       
-          assertComputed(player, '750px', '--video-min-width');
-          assertComputed(player, '300px', '--video-min-height');
-
           const title = player.shadowRoot.querySelector('.title');
           assertComputed(title, 'red', '--video-title-color');
       


### PR DESCRIPTION
- I believe this should be not part of the shadow DOM nor should there be a default min height/width to use.
- If you wish to specify the minimum width and height of the component, then use the appropriate CSS selectors like you would with any other standard HTML element.
